### PR TITLE
Refactor reports to use SingleReportData model

### DIFF
--- a/src/app/dialogs/real-time-chart/real-time-chart.html
+++ b/src/app/dialogs/real-time-chart/real-time-chart.html
@@ -1,4 +1,5 @@
-<h1 mat-dialog-title>Monitorização em Tempo Real: {{ machineData.machine.nomeMaquina }}</h1>
+<!-- CORREÇÃO: A propriedade foi atualizada para 'initialReportData.report' para corresponder ao ficheiro .ts -->
+<h1 mat-dialog-title>Monitorização em Tempo Real (Usuário: {{ initialReportData.report.usuario }})</h1>
 
 <div mat-dialog-content>
   <!-- Gráfico de Corrente -->

--- a/src/app/features/machines-report/machines-report.html
+++ b/src/app/features/machines-report/machines-report.html
@@ -1,88 +1,71 @@
-  <!-- Tabela com os dados detalhados -->
-  <h2>Detalhes por Máquina</h2>
-<table mat-table [dataSource]="reportData" class="mat-elevation-z8">
+<h2>Detalhes do Último Relatório</h2>
+<!-- 
+  O truque está aqui: [dataSource]="[reportData]".
+  Como a Mat-Table espera um array, nós criamos um array contendo
+  o nosso único objeto 'reportData'.
+-->
+<table mat-table [dataSource]="reportData ? [reportData] : []" class="mat-elevation-z8" *ngIf="reportData">
 
-  <!-- Coluna: Máquina -->
-  <ng-container matColumnDef="nomeMaquina">
-    <th mat-header-cell *matHeaderCellDef> Máquina </th>
-    <td mat-cell *matCellDef="let element"> {{element.nomeMaquina}} </td>
+  <!-- Coluna: Data e Hora -->
+  <ng-container matColumnDef="data_hora">
+    <th mat-header-cell *matHeaderCellDef> Data e Hora </th>
+    <td mat-cell *matCellDef="let element"> {{element.data_hora | date:'dd/MM/yyyy HH:mm:ss'}} </td>
   </ng-container>
 
-  <!-- Coluna: Status -->
-  <ng-container matColumnDef="status">
-    <th mat-header-cell *matHeaderCellDef> Status </th>
-    <td mat-cell *matCellDef="let element"> {{element.status}} </td>
+  <!-- Coluna: Nível Conz1 -->
+  <ng-container matColumnDef="conz1_nivel">
+    <th mat-header-cell *matHeaderCellDef> Nível Conz1 </th>
+    <td mat-cell *matCellDef="let element"> {{element.conz1_nivel.toFixed(2)}} </td>
   </ng-container>
 
-  <!-- Coluna: Corrente -->
-  <ng-container matColumnDef="corrente">
-    <th mat-header-cell *matHeaderCellDef> Corrente (A) </th>
-    <td mat-cell *matCellDef="let element"> {{element.corrente.toFixed(2)}} A </td>
+  <!-- Coluna: Nível Conz2 -->
+  <ng-container matColumnDef="conz2_nivel">
+    <th mat-header-cell *matHeaderCellDef> Nível Conz2 </th>
+    <td mat-cell *matCellDef="let element"> {{element.conz2_nivel.toFixed(2)}} </td>
   </ng-container>
 
   <!-- Coluna: Temperatura -->
-  <ng-container matColumnDef="temperatura">
+  <ng-container matColumnDef="tem2_c">
     <th mat-header-cell *matHeaderCellDef> Temp. (°C) </th>
-    <td mat-cell *matCellDef="let element"> {{element.temperatura.toFixed(1)}} °C </td>
+    <td mat-cell *matCellDef="let element"> {{element.tem2_c.toFixed(1)}} °C </td>
   </ng-container>
 
-  <!-- Coluna: Nível -->
-  <ng-container matColumnDef="nivel">
-    <th mat-header-cell *matHeaderCellDef> Nível (%) </th>
-    <td mat-cell *matCellDef="let element"> {{element.nivel.toFixed(1)}}% </td>
-  </ng-container>
-
-  <!-- Coluna: Horas Trabalhadas -->
-  <ng-container matColumnDef="horasTrabalhadas">
-    <th mat-header-cell *matHeaderCellDef> Horas Ativas </th>
-    <td mat-cell *matCellDef="let element"> {{element.horasTrabalhadas.toFixed(1)}}h </td>
-  </ng-container>
-
-  <!-- Coluna: Horas Inativas -->
-  <ng-container matColumnDef="horasInativas">
-    <th mat-header-cell *matHeaderCellDef> Horas Inativas </th>
-    <td mat-cell *matCellDef="let element"> {{element.horasInativas.toFixed(1)}}h </td>
+  <!-- Coluna: Corrente Pre1 -->
+  <ng-container matColumnDef="pre1_amp">
+    <th mat-header-cell *matHeaderCellDef> Corrente Pre1 (A) </th>
+    <td mat-cell *matCellDef="let element"> {{element.pre1_amp.toFixed(2)}} A </td>
   </ng-container>
   
-  <!-- Coluna: Dias Trabalhados -->
-  <ng-container matColumnDef="diasTrabalhados">
-    <th mat-header-cell *matHeaderCellDef> Dias Operando </th>
-    <td mat-cell *matCellDef="let element"> {{element.diasTrabalhados}} </td>
+  <!-- Adicione as outras colunas (pre2_amp, pre3_amp, pre4_amp, q90h, usuario) seguindo o mesmo padrão -->
+  <ng-container matColumnDef="pre2_amp">
+    <th mat-header-cell *matHeaderCellDef> Corrente Pre2 (A) </th>
+    <td mat-cell *matCellDef="let element"> {{element.pre2_amp.toFixed(2)}} A </td>
   </ng-container>
 
-  <!-- Coluna: Eficiência -->
-  <ng-container matColumnDef="eficiencia">
-    <th mat-header-cell *matHeaderCellDef> Eficiência (%) </th>
-    <td mat-cell *matCellDef="let element"> {{element.eficiencia.toFixed(1)}}% </td>
+  <ng-container matColumnDef="pre3_amp">
+    <th mat-header-cell *matHeaderCellDef> Corrente Pre3 (A) </th>
+    <td mat-cell *matCellDef="let element"> {{element.pre3_amp.toFixed(2)}} A </td>
   </ng-container>
 
-  <!-- Coluna: Próx. Manutenção -->
-  <ng-container matColumnDef="proximaManutencao">
-    <th mat-header-cell *matHeaderCellDef> Próx. Manutenção </th>
-    <td mat-cell *matCellDef="let element">
-      <!-- Aqui podemos usar o componente <app-maintenance-status> no futuro -->
-      <div class="manutencao-container">
-        <span>{{element.proximaManutencao}} dias</span>
-        <div class="progress-bar-background">
-          <div class="progress-bar-fill"
-               [style.width.%]="(element.proximaManutencao / 90) * 100"
-               [ngClass]="getManutencaoStatus(element.proximaManutencao)">
-          </div>
-        </div>
-      </div>
-    </td>
+  <ng-container matColumnDef="pre4_amp">
+    <th mat-header-cell *matHeaderCellDef> Corrente Pre4 (A) </th>
+    <td mat-cell *matCellDef="let element"> {{element.pre4_amp.toFixed(2)}} A </td>
   </ng-container>
 
-  <!-- Coluna: Ações -->
-  <ng-container matColumnDef="grafico">
-    <th mat-header-cell *matHeaderCellDef> Gráfico </th>
-    <td mat-cell *matCellDef="let element">
-      <button mat-icon-button color="primary" (click)="onAbrirGrafico(element)">
-        <mat-icon>show_chart</mat-icon>
-      </button>
-    </td>
+  <ng-container matColumnDef="q90h">
+    <th mat-header-cell *matHeaderCellDef> Eficiência (q90h) </th>
+    <td mat-cell *matCellDef="let element"> {{element.q90h.toFixed(1)}}% </td>
+  </ng-container>
+
+  <ng-container matColumnDef="usuario">
+    <th mat-header-cell *matHeaderCellDef> Usuário </th>
+    <td mat-cell *matCellDef="let element"> {{element.usuario}} </td>
   </ng-container>
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
+
+<div *ngIf="!reportData" class="loading-message">
+  A aguardar o primeiro relatório...
+</div>

--- a/src/app/features/machines-report/machines-report.ts
+++ b/src/app/features/machines-report/machines-report.ts
@@ -3,11 +3,10 @@ import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
-import { DailyReportData } from '../../modal/daily-report-data/daily-report-data'; 
-import { ReportDataService } from '../../services/report-data';
-import { MatDialog } from '@angular/material/dialog';
-import { RealTimeChartComponent } from '../../dialogs/real-time-chart/real-time-chart';
 import { MatButtonModule } from '@angular/material/button';
+
+// Importamos a nova interface
+import { SingleReportData } from '../../modal/single-report-data/single-report-data';
 
 @Component({
   selector: 'app-machines-report',
@@ -18,35 +17,35 @@ import { MatButtonModule } from '@angular/material/button';
 })
 export class MachinesReport {
 
-  @Input() reportData: DailyReportData[] = [];
-  @Output() viewChartClicked = new EventEmitter<DailyReportData>();
+  // O Input agora espera um único objeto, que pode ser nulo
+  @Input() reportData: SingleReportData | null = null;
+  @Output() viewChartClicked = new EventEmitter<SingleReportData>();
 
-  // ATUALIZAÇÃO: Adicionamos todas as colunas que vêm da API
+  // As colunas agora devem corresponder aos nomes da nova interface
   displayedColumns: string[] = [
-    'nomeMaquina', 
-    'status', 
-    'corrente', 
-    'temperatura', 
-    'nivel', 
-    'horasTrabalhadas', 
-    'horasInativas', 
-    'diasTrabalhados', 
-    'eficiencia', 
-    'proximaManutencao', 
-    'grafico'
+    'data_hora',
+    'conz1_nivel', 
+    'conz2_nivel', 
+    'tem2_c', 
+    'pre1_amp',
+    'pre2_amp',
+    'pre3_amp',
+    'pre4_amp',
+    'q90h',
+    'usuario',
+    // 'grafico' // Coluna de ações
   ];
 
   constructor() {}
 
+  // Este método pode não ser mais necessário se não houver "dias" na nova estrutura
   getManutencaoStatus(dias: number): string {
     if (dias <= 15) return 'alarme';
     if (dias <= 45) return 'atencao';
     return 'normal';
   }
 
-  onAbrirGrafico(machineData: DailyReportData): void {
-    console.log('Botão clicado no componente filho! A emitir evento...');
-    // 3. Use o emissor para "disparar" o evento para o pai, enviando os dados da máquina
+  onAbrirGrafico(machineData: SingleReportData): void {
     this.viewChartClicked.emit(machineData);
   }
 }

--- a/src/app/modal/single-report-data/single-report-data.ts
+++ b/src/app/modal/single-report-data/single-report-data.ts
@@ -1,0 +1,14 @@
+export interface SingleReportData {
+  report_id: number;
+  conz1_nivel: number;
+  conz2_nivel: number;
+  data_hora: string; // Ou Date, se preferir tratar como objeto Date
+  excel_id: number;
+  pre1_amp: number;
+  pre2_amp: number;
+  pre3_amp: number;
+  pre4_amp: number;
+  q90h: number;
+  tem2_c: number;
+  usuario: string;
+}

--- a/src/app/pages/daily-report/daily-report.html
+++ b/src/app/pages/daily-report/daily-report.html
@@ -1,67 +1,40 @@
-<!-- Ficheiro: src/app/pages/daily-report/daily-report.html -->
-<div class="report-container">
-  <h1>Relatório Diário de Produção</h1>
-  <p class="report-date">Data: 14 de Julho de 2025</p>
+<div class="container">
 
-  <div class="actions-header">
-    <app-save-button (saveClicked)="salvarRelatorio()"></app-save-button>
-  </div>
-  <!-- Secção de KPIs com Cards -->
-  <div class="kpi-grid">
-    @if (maquinaMaisTrabalhadora) {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>Máquina Mais Produtiva</mat-card-title>
-          <mat-card-subtitle>Equipamento com mais horas de operação</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-            <p class="kpi-value">{{ maquinaMaisTrabalhadora.nomeMaquina }}</p>
-            <p class="kpi-sub-value">{{ maquinaMaisTrabalhadora.horasTrabalhadas.toFixed(1) }} horas</p>
-        </mat-card-content>
-      </mat-card>
-    } @else {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>Máquina Mais Produtiva</mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
-          <p class="kpi-value">Calculando...</p>
-        </mat-card-content>
-      </mat-card>
-    }
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>Consumo Total de Corrente</mat-card-title>
-        <mat-card-subtitle>Soma de todos os equipamentos</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <p class="kpi-value">{{ consumoTotalCorrente.toFixed(2) }} kWh</p>
-      </mat-card-content>
-    </mat-card>
+  <mat-card class="kpi-container">
+    <!-- Removida a seção 'Máquina Mais Produtiva' -->
 
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>Eficiência Média da Planta</mat-card-title>
-        <mat-card-subtitle>Média de todas as máquinas</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <p class="kpi-value">{{ eficienciaMedia.toFixed(2) }} %</p>
-      </mat-card-content>
-    </mat-card>
+    <div class="kpi-card">
+      <mat-icon class="kpi-icon">flash_on</mat-icon>
+      <div>
+        <p class="kpi-title">Consumo Total</p>
+        <p class="kpi-value">{{ consumoTotalCorrente.toFixed(2) }} A</p>
+        <p class="kpi-sub-value">Corrente somada</p>
+      </div>
+    </div>
 
-  <mat-card>
-    <mat-card-header>
-      <mat-card-title>Alertas no Dia</mat-card-title>
-      <mat-card-subtitle>Máquinas com anomalias ou paradas</mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      <p class="kpi-value">{{ alertasNoDia }}</p>
-    </mat-card-content>
+    <div class="kpi-card">
+      <mat-icon class="kpi-icon">trending_up</mat-icon>
+      <div>
+        <p class="kpi-title">Eficiência Média</p>
+        <p class="kpi-value">{{ eficienciaMedia.toFixed(1) }}%</p>
+        <p class="kpi-sub-value">Média geral</p>
+      </div>
+    </div>
+
+    <div class="kpi-card">
+      <mat-icon class="kpi-icon">warning</mat-icon>
+      <div>
+        <p class="kpi-title">Alertas no Dia</p>
+        <p class="kpi-value">{{ alertasNoDia }}</p>
+        <p class="kpi-sub-value">Registos críticos</p>
+      </div>
+    </div>
   </mat-card>
-</div>
+
   <!-- Tabela com os dados detalhados -->
+  <!-- CORREÇÃO: Passando [reportData]="latestReport" para o componente filho -->
   <app-machines-report 
-    [reportData]="reportData"
+    [reportData]="latestReport" 
     (viewChartClicked)="abrirGrafico($event)">
   </app-machines-report>
 </div>

--- a/src/app/pages/daily-report/daily-report.ts
+++ b/src/app/pages/daily-report/daily-report.ts
@@ -1,22 +1,20 @@
-// Ficheiro: src/app/pages/daily-report/daily-report.component.ts
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
-import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
-import { RealTimeChartComponent } from '../../dialogs/real-time-chart/real-time-chart';
+import { Subscription, interval } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
-// 1. Importamos a interface do nosso ficheiro de modelo
-import { DailyReportData } from '../../modal/daily-report-data/daily-report-data'; 
-// 2. Importamos o serviço do ficheiro .service.ts
-import { ReportDataService } from '../../services/report-data'; // Corrigido o caminho para .service
-// 3. Importamos os componentes filhos que serão usados no template
+// Importamos a NOVA interface
+import { SingleReportData } from '../../modal/single-report-data/single-report-data'; 
+import { ReportDataService } from '../../services/report-data'; 
+
+// Importamos o componente da tabela
 import { MachinesReport } from "../../features/machines-report/machines-report";
 import { SaveButtonComponent } from '../../components/save-button/save-button';
-
-import { Subscription, interval } from 'rxjs'
-import { switchMap } from 'rxjs/operators';
+// O RealTimeChartComponent pode precisar de ajustes dependendo do que ele espera receber
+// import { RealTimeChartComponent } from '../../dialogs/real-time-chart/real-time-chart';
 
 @Component({
   selector: 'app-daily-report',
@@ -24,9 +22,8 @@ import { switchMap } from 'rxjs/operators';
   imports: [
     CommonModule, 
     MatCardModule, 
-    MatTableModule, 
     MatIconModule, 
-    MachinesReport,
+    MachinesReport, // Nosso componente de tabela
     SaveButtonComponent,
   ],
   templateUrl: './daily-report.html',
@@ -34,18 +31,15 @@ import { switchMap } from 'rxjs/operators';
 })
 export class DailyReportComponent implements OnInit, OnDestroy {
 
-  reportData: DailyReportData[] = [];
-  maquinaMaisTrabalhadora: DailyReportData | undefined;
+  // Agora temos um único objeto, que pode ser nulo antes de carregar
+  latestReport: SingleReportData | null = null;
+  
+  // Os KPIs podem ser calculados diretamente a partir do latestReport
   consumoTotalCorrente = 0;
   eficienciaMedia = 0;
   alertasNoDia = 0;
 
-  private readonly LIMITE_TEMPERATURA = 90.0; // Ex: Alerta acima de 90°C
-  private readonly LIMITE_CORRENTE = 180.0; // Ex: Alerta acima de 180A
-
   private dataSubscription!: Subscription;
-
-  displayedColumns: string[] = ['nomeMaquina', 'horasTrabalhadas', 'consumoCorrente', 'eficiencia', 'diasTrabalhados', 'proximaManutencao', 'acoes'];
 
   constructor(
     private reportService: ReportDataService, 
@@ -53,81 +47,30 @@ export class DailyReportComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    // --- LÓGICA EXISTENTE PARA ATUALIZAÇÃO EM TEMPO REAL ---
-    // Esta parte continua a buscar os dados a cada segundo.
-    this.dataSubscription = interval(1000)
+    this.dataSubscription = interval(2000) // Aumentei o intervalo para 2s
       .pipe(
-        // O switchMap cancela a requisição anterior se uma nova começar
-        switchMap(() => this.reportService.getDailyReport())
+        // A cada 2 segundos, busca o último relatório
+        switchMap(() => this.reportService.getLatestReport())
       )
       .subscribe(data => {
-        console.log('Dados atualizados em tempo real!', data);
-        this.reportData = data;
-        this.calcularKPIs();
+        console.log('Último relatório recebido!', data);
+        this.latestReport = data;
+        this.calcularKPIs(); // Recalcula os KPIs com os novos dados
       });
-
-    // --- NOVA LÓGICA PARA TESTAR A BUSCA POR DATA/HORA ---
-    // Esta função será chamada uma única vez quando o componente iniciar.
-    this.testarBuscaPorDataHora();
-  }
-
-  /**
-   * Função de teste para chamar o novo método do serviço e exibir o resultado no console.
-   */
-  testarBuscaPorDataHora(): void {
-    // Defina aqui a data e hora exata que você quer buscar.
-    // IMPORTANTE: Use uma data e hora que você TENHA CERTEZA que existe no seu banco de dados.
-    const dataHoraParaTeste = '2025-08-15 10:00:00'; // <-- MUDE AQUI SE NECESSÁRIO
-
-    console.log(`%c[TESTE] A solicitar relatório para: ${dataHoraParaTeste}`, 'color: blue; font-weight: bold;');
-
-    this.reportService.getReportByDateTime(dataHoraParaTeste).subscribe({
-      next: (dadosDoRelatorio) => {
-        // Sucesso! Os dados chegaram.
-        console.log('%c[TESTE] Relatório específico recebido com SUCESSO:', 'color: green; font-weight: bold;', dadosDoRelatorio);
-      },
-      error: (erro) => {
-        // Ocorreu um erro.
-        console.error('%c[TESTE] Falha ao buscar o relatório específico:', 'color: red; font-weight: bold;', erro);
-      }
-    });
-  }
-
-  // --- MÉTODOS EXISTENTES DO COMPONENTE ---
-
-  salvarRelatorio(): void {
-    if (this.reportData.length === 0) {
-      // Usar um modal ou um snackbar seria melhor que um alert.
-      console.warn('Não há dados para salvar e baixar.');
-      return;
-    }
-    // Lógica para salvar o relatório...
   }
 
   calcularKPIs(): void {
-    if (!this.reportData || this.reportData.length === 0) {
-      this.maquinaMaisTrabalhadora = undefined;
-      this.consumoTotalCorrente = 0;
-      this.eficienciaMedia = 0;
-      this.alertasNoDia = 0;
-      return;
+    if (!this.latestReport) {
+      return; // Se não há dados, não faz nada
     }
-
-    this.alertasNoDia = this.reportData.filter(item => {
-      const statusAnormal = item.status !== 'Operando';
-      const temperaturaElevada = item.temperatura > this.LIMITE_TEMPERATURA;
-      const correnteIrregular = item.corrente > this.LIMITE_CORRENTE;
-      return statusAnormal || temperaturaElevada || correnteIrregular;
-    }).length;
-
-    this.maquinaMaisTrabalhadora = this.reportData.reduce((prev, current) =>
-      (prev.horasTrabalhadas > current.horasTrabalhadas) ? prev : current
-    );
-
-    this.consumoTotalCorrente = this.reportData.reduce((acc, item) => acc + (item.consumoCorrente || 0), 0);
-
-    const totalEficiencia = this.reportData.reduce((acc, item) => acc + item.eficiencia, 0);
-    this.eficienciaMedia = totalEficiencia / this.reportData.length;
+    // Lógica de cálculo de KPIs baseada em UM único relatório
+    // Exemplo:
+    this.consumoTotalCorrente = this.latestReport.pre1_amp + this.latestReport.pre2_amp + this.latestReport.pre3_amp + this.latestReport.pre4_amp;
+    this.eficienciaMedia = this.latestReport.q90h; // Supondo que q90h seja a eficiência
+    
+    // Lógica de alertas
+    const temperaturaElevada = this.latestReport.tem2_c > 90.0;
+    this.alertasNoDia = temperaturaElevada ? 1 : 0;
   }
 
   ngOnDestroy(): void {
@@ -136,17 +79,8 @@ export class DailyReportComponent implements OnInit, OnDestroy {
     }
   }
 
-  getManutencaoStatus(dias: number): string {
-    if (dias <= 15) return 'alarme';
-    if (dias <= 45) return 'atencao';
-    return 'normal';
-  }
-
-  abrirGrafico(machineData: DailyReportData): void {
-    console.log('Evento recebido pelo pai! A abrir o modal para:', machineData.nomeMaquina);
-    this.dialog.open(RealTimeChartComponent, {
-      width: '800px',
-      data: { machine: machineData }
-    });
+  abrirGrafico(report: SingleReportData): void {
+    console.log('Abrir gráfico para:', report);
+    // A lógica do modal pode precisar ser ajustada para receber um SingleReportData
   }
 }

--- a/src/app/services/report-data-time.service.ts
+++ b/src/app/services/report-data-time.service.ts
@@ -1,41 +1,47 @@
 import { Injectable } from '@angular/core';
-import { interval, Observable, of } from 'rxjs';
+import { interval, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { ReportDataService } from './report-data'; // 1. Importe o serviço principal
+import { SingleReportData } from '../modal/single-report-data/single-report-data'; // 2. Importe a nova interface
 
 @Injectable({
   providedIn: 'root'
 })
 export class RealTimeDataService {
 
-  // 2. Injete o ReportDataService para ter acesso aos dados da API
   constructor(private reportService: ReportDataService) { }
 
   /**
-   * ATUALIZADO: Busca a corrente real da máquina a cada 2 segundos.
+   * REATORIZADO: Busca a SOMA DAS CORRENTES do último relatório a cada 2 segundos.
+   * O parâmetro 'machineName' não é mais necessário, pois sempre pegamos os dados do último registo.
    */
-  getRealTimeCurrentData(machineName: string): Observable<number> {
+  getRealTimeCurrentData(): Observable<number> {
     return interval(2000).pipe(
-      // A cada 2 segundos, busca a lista completa de relatórios
-      switchMap(() => this.reportService.getDailyReport()),
-      // "Mapeia" a lista para encontrar a nossa máquina e devolver apenas a sua corrente
-      map(reports => {
-        const machine = reports.find(r => r.nomeMaquina === machineName);
-        // Se a máquina for encontrada, retorna a sua corrente; caso contrário, retorna 0
-        return machine ? machine.corrente : 0;
+      // A cada 2 segundos, busca o último relatório completo
+      switchMap(() => this.reportService.getLatestReport()),
+      // "Mapeia" o objeto do relatório para calcular e devolver a soma das correntes
+      map((report: SingleReportData) => {
+        // Se o relatório não existir, retorna 0
+        if (!report) {
+          return 0;
+        }
+        // Soma as correntes de todas as fases (pre1_amp, pre2_amp, etc.)
+        return report.pre1_amp + report.pre2_amp + report.pre3_amp + report.pre4_amp;
       })
     );
   }
 
   /**
-   * ATUALIZADO: Busca a temperatura real da máquina a cada 2 segundos.
+   * REATORIZADO: Busca a TEMPERATURA do último relatório a cada 2 segundos.
    */
-  getRealTimeTemperatureData(machineName: string): Observable<number> {
+  getRealTimeTemperatureData(): Observable<number> {
     return interval(2000).pipe(
-      switchMap(() => this.reportService.getDailyReport()),
-      map(reports => {
-        const machine = reports.find(r => r.nomeMaquina === machineName);
-        return machine ? machine.temperatura : 0;
+      // A cada 2 segundos, busca o último relatório completo
+      switchMap(() => this.reportService.getLatestReport()),
+      // Mapeia o objeto do relatório para devolver apenas a sua temperatura
+      map((report: SingleReportData) => {
+        // Se o relatório for encontrado, retorna a sua temperatura; caso contrário, retorna 0
+        return report ? report.tem2_c : 0;
       })
     );
   }

--- a/src/app/services/report-data.ts
+++ b/src/app/services/report-data.ts
@@ -1,37 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
-import { Observable, of, interval, map, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 
+// Imports necessários
+import { SingleReportData } from '../modal/single-report-data/single-report-data';
 import { HistoryDetailsModal } from '../modal/history-details-modal/history-details-modal';
-import { DailyReportData } from '../modal/daily-report-data/daily-report-data';
-
-// Interface para mapear a resposta da API que pode ter nomes de propriedade inconsistentes
-interface ReportApiResponse {
-  reportId?: number;
-  report_id?: number;
-  nomeMaquina?: string;
-  nome_maquina?: string;
-  horasTrabalhadas?: number;
-  horas_trabalhadas?: number;
-  horasInativas?: number;
-  horas_inativas?: number;
-  corrente?: number;
-  eficiencia?: number;
-  nivel?: number;
-  temperatura?: number;
-  status?: string;
-  diasTrabalhados?: number;
-  dias_trabalhados?: number;
-  proximaManutencao?: number;
-  proxima_manutencao?: number;
-  consumoCorrente?: number;
-  consumo_energia?: number;
-}
-
-export interface SnapshotResponse {
-  historyId: number;
-}
 
 @Injectable({
   providedIn: 'root'
@@ -41,105 +15,53 @@ export class ReportDataService {
 
   constructor(private http: HttpClient) { }
 
-  // --- MÉTODOS EXISTENTES ---
-
-  getDailyReport(): Observable<DailyReportData[]> {
+  /**
+   * Busca apenas o último registo da tabela de relatórios.
+   * @returns Um Observable que emite um único objeto SingleReportData.
+   */
+  getLatestReport(): Observable<SingleReportData> {
     const token = localStorage.getItem('user_token');
     const headers = new HttpHeaders({ 'Authorization': `Bearer ${token}` });
+    const latestReportUrl = `${this.API_URL}/latest`;
 
-    return this.http.get<ReportApiResponse[]>(this.API_URL, { headers }).pipe(
-      map(apiResponse => {
-        if (!apiResponse) return [];
-        
-        return apiResponse.map(item => ({
-          reportId: item.reportId || item.report_id || 0,
-          nomeMaquina: item.nomeMaquina || item.nome_maquina || 'Nome Indisponível',
-          horasTrabalhadas: item.horasTrabalhadas || item.horas_trabalhadas || 0,
-          horasInativas: item.horasInativas || item.horas_inativas || 0,
-          corrente: item.corrente || 0,
-          eficiencia: item.eficiencia || 0,
-          nivel: item.nivel || 0,
-          temperatura: item.temperatura || 0,
-          status: item.status || 'Desconhecido',
-          diasTrabalhados: item.diasTrabalhados || item.dias_trabalhados || 0,
-          proximaManutencao: item.proximaManutencao || item.proxima_manutencao || 0,
-          consumoCorrente: item.consumoCorrente || item.consumo_energia || 0
-        }));
-      }),
-      catchError(this.handleError) // Adicionado tratamento de erro aqui também
+    return this.http.get<SingleReportData>(latestReportUrl, { headers }).pipe(
+      tap(data => console.log('Serviço: Último relatório recebido:', data)),
+      catchError(this.handleError)
     );
   }
-
-  createReport(report: DailyReportData): Observable<void> {
-    console.log('Serviço está a ARMAZENAR dados na API...', report);
-    
+  
+  /**
+   * Busca um registo de relatório específico com base numa data e hora.
+   * @param dateTimeString Uma string representando a data e hora.
+   * @returns Um Observable que emite os dados do relatório encontrado.
+   */
+  getReportByDateTime(dateTimeString: string): Observable<SingleReportData> {
     const token = localStorage.getItem('user_token');
-    const headers = new HttpHeaders({
-      'Authorization': `Bearer ${token}`
-    });
-
-    return this.http.post<void>(this.API_URL, report, { headers }).pipe(
-      tap(() => console.log('Dados armazenados com sucesso!')),
+    const headers = new HttpHeaders({ 'Authorization': `Bearer ${token}` });
+    const encodedDateTime = encodeURIComponent(dateTimeString);
+    const url = `${this.API_URL}/by-date/${encodedDateTime}`;
+    
+    return this.http.get<SingleReportData>(url, { headers }).pipe(
+      tap(data => console.log(`Serviço: Relatório para ${dateTimeString} recebido.`, data)),
       catchError(this.handleError)
     );
   }
 
+  /**
+   * Busca um histórico mockado de relatórios.
+   */
   getReportHistory(): Observable<HistoryDetailsModal[]> {
     console.log('A buscar dados mocados do histórico...');
     const mockHistory: HistoryDetailsModal[] = [
       { id: '20250714', data: '14/07/2025', resumo: 'Eficiência média: 98.2%. 2 Alertas registados.' },
       { id: '20250713', data: '13/07/2025', resumo: 'Eficiência média: 97.5%. 1 Alarme crítico.' },
-      { id: '20250712', data: '12/07/2025', resumo: 'Eficiência média: 99.1%. Operação normal.' }
     ];
     return of(mockHistory);
   }
 
-  saveReportSnapshot(reportData: DailyReportData[]): Observable<SnapshotResponse> {
-    const token = localStorage.getItem('user_token');
-    const headers = new HttpHeaders({ 'Authorization': `Bearer ${token}` });
-    return this.http.post<SnapshotResponse>(`${this.API_URL}/history`, reportData, { headers });
-  }
-
-  getRealTimeCurrentData() {
-    return interval(1500).pipe(
-      map(() => 20 + (Math.random() * 10 - 5))
-    );
-  }
-
-  // --- NOVO MÉTODO ADICIONADO ---
-
   /**
-   * Busca um registo de relatório específico com base numa data e hora.
-   * @param dateTimeString Uma string representando a data e hora (ex: '2025-08-15 10:00:00').
-   * @returns Um Observable que emite os dados do relatório encontrado.
+   * Função privada para tratamento centralizado de erros de HTTP.
    */
-  getReportByDateTime(dateTimeString: string): Observable<any> {
-    // 1. Log para depuração: Informa que a função foi chamada.
-    console.log(`Serviço: A iniciar busca para a data/hora: ${dateTimeString}`);
-
-    // 2. Obtenção do token de autenticação, essencial para a segurança.
-    const token = localStorage.getItem('user_token');
-    const headers = new HttpHeaders({ 'Authorization': `Bearer ${token}` });
-
-    // 3. Codificação da data/hora para uma URL segura.
-    const encodedDateTime = encodeURIComponent(dateTimeString);
-
-    // 4. Construção da URL final para a API.
-    const url = `${this.API_URL}/by-date/${encodedDateTime}`;
-    console.log(`Serviço: URL do pedido GET: ${url}`);
-
-    // 5. Execução do pedido HTTP GET.
-    return this.http.get<any>(url, { headers }).pipe(
-      tap(data => {
-        console.log('Serviço: Resposta da API recebida com sucesso.', data);
-      }),
-      catchError(this.handleError) // Reutiliza a função de tratamento de erros
-    );
-  }
-
-
-  // --- FUNÇÃO PRIVADA DE TRATAMENTO DE ERROS ---
-
   private handleError(error: HttpErrorResponse) {
     if (error.status === 401) {
       console.error('Erro de Autenticação! O token pode ser inválido ou ter expirado.', error);


### PR DESCRIPTION
Replaces DailyReportData usage with SingleReportData throughout the app, updating components, services, and templates to work with a single report object instead of arrays. Adjusts real-time chart and machine report logic, updates KPI calculations, and streamlines API calls to fetch only the latest report. Adds the new SingleReportData interface and removes legacy fields and logic tied to the old data structure.