### PR TITLE
Add date range filter to daily report page

### DIFF
--- a/src/app/pages/daily-report/daily-report.html
+++ b/src/app/pages/daily-report/daily-report.html
@@ -1,8 +1,6 @@
 <div class="container">
-
+  <!-- Seus KPIs existentes -->
   <mat-card class="kpi-container">
-    <!-- Removida a seção 'Máquina Mais Produtiva' -->
-
     <div class="kpi-card">
       <mat-icon class="kpi-icon">flash_on</mat-icon>
       <div>
@@ -11,7 +9,6 @@
         <p class="kpi-sub-value">Corrente somada</p>
       </div>
     </div>
-
     <div class="kpi-card">
       <mat-icon class="kpi-icon">trending_up</mat-icon>
       <div>
@@ -20,7 +17,6 @@
         <p class="kpi-sub-value">Média geral</p>
       </div>
     </div>
-
     <div class="kpi-card">
       <mat-icon class="kpi-icon">warning</mat-icon>
       <div>
@@ -31,10 +27,68 @@
     </div>
   </mat-card>
 
-  <!-- Tabela com os dados detalhados -->
-  <!-- CORREÇÃO: Passando [reportData]="latestReport" para o componente filho -->
-  <app-machines-report 
-    [reportData]="latestReport" 
-    (viewChartClicked)="abrirGrafico($event)">
-  </app-machines-report>
+  <!-- NOVA SEÇÃO DE FILTRO -->
+  <mat-card class="filter-card">
+    <mat-card-header>
+      <mat-card-title>Filtrar Relatórios por Período</mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="filter-content">
+      <mat-form-field appearance="fill">
+        <mat-label>Data e Hora de Início</mat-label>
+        <input matInput type="datetime-local" [(ngModel)]="dataInicio">
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Data e Hora de Fim</mat-label>
+        <input matInput type="datetime-local" [(ngModel)]="dataFim">
+      </mat-form-field>
+
+      <div class="filter-actions">
+        <button mat-raised-button color="primary" (click)="filtrarRelatorios()">Filtrar</button>
+        <button mat-stroked-button color="accent" (click)="limparFiltro()" *ngIf="modoFiltro">Limpar Filtro</button>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- EXIBIÇÃO CONDICIONAL DOS DADOS -->
+
+  <!-- 1. Mostra o componente de tempo real se NÃO estiver em modo de filtro -->
+  <div *ngIf="!modoFiltro">
+    <app-machines-report 
+      [reportData]="latestReport">
+    </app-machines-report>
+  </div>
+
+  <!-- 2. Mostra a tabela de resultados filtrados se ESTIVER em modo de filtro -->
+  <div *ngIf="modoFiltro">
+    <h2>Resultados do Filtro ({{ relatoriosFiltrados.length }} registos)</h2>
+    
+    <div *ngIf="isLoading" class="loading-message">
+      A carregar dados filtrados...
+    </div>
+
+    <!-- Tabela simples para exibir os dados filtrados -->
+    <table mat-table [dataSource]="relatoriosFiltrados" class="mat-elevation-z8" *ngIf="!isLoading">
+      <!-- Definição das colunas (exemplo) -->
+      <ng-container matColumnDef="data_hora">
+        <th mat-header-cell *matHeaderCellDef> Data e Hora </th>
+        <td mat-cell *matCellDef="let row"> {{ row.data_hora | date:'dd/MM/yyyy HH:mm:ss' }} </td>
+      </ng-container>
+      <ng-container matColumnDef="usuario">
+        <th mat-header-cell *matHeaderCellDef> Usuário </th>
+        <td mat-cell *matCellDef="let row"> {{ row.usuario }} </td>
+      </ng-container>
+      <ng-container matColumnDef="tem2_c">
+        <th mat-header-cell *matHeaderCellDef> Temperatura </th>
+        <td mat-cell *matCellDef="let row"> {{ row.tem2_c.toFixed(1) }} °C </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="['data_hora', 'usuario', 'tem2_c']"></tr>
+      <tr mat-row *matRowDef="let row; columns: ['data_hora', 'usuario', 'tem2_c'];"></tr>
+    </table>
+    
+    <div *ngIf="!isLoading && relatoriosFiltrados.length === 0" class="no-results-message">
+      Nenhum relatório encontrado para o período selecionado.
+    </div>
+  </div>
 </div>

--- a/src/app/pages/daily-report/daily-report.ts
+++ b/src/app/pages/daily-report/daily-report.ts
@@ -1,45 +1,52 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTableModule } from '@angular/material/table'; // Import para a tabela de filtro
 import { Subscription, interval } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
-// Importamos a NOVA interface
 import { SingleReportData } from '../../modal/single-report-data/single-report-data'; 
 import { ReportDataService } from '../../services/report-data'; 
-
-// Importamos o componente da tabela
 import { MachinesReport } from "../../features/machines-report/machines-report";
-import { SaveButtonComponent } from '../../components/save-button/save-button';
-// O RealTimeChartComponent pode precisar de ajustes dependendo do que ele espera receber
-// import { RealTimeChartComponent } from '../../dialogs/real-time-chart/real-time-chart';
 
 @Component({
   selector: 'app-daily-report',
   standalone: true,
   imports: [
     CommonModule, 
+    FormsModule,
     MatCardModule, 
     MatIconModule, 
-    MachinesReport, // Nosso componente de tabela
-    SaveButtonComponent,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatTableModule,
+    MachinesReport,
   ],
   templateUrl: './daily-report.html',
   styleUrl: './daily-report.css'
 })
 export class DailyReportComponent implements OnInit, OnDestroy {
 
-  // Agora temos um único objeto, que pode ser nulo antes de carregar
+  // Propriedades existentes
   latestReport: SingleReportData | null = null;
-  
-  // Os KPIs podem ser calculados diretamente a partir do latestReport
   consumoTotalCorrente = 0;
   eficienciaMedia = 0;
   alertasNoDia = 0;
-
   private dataSubscription!: Subscription;
+
+  // --- NOVAS PROPRIEDADES PARA O FILTRO ---
+  public dataInicio: string = '';
+  public dataFim: string = '';
+  public relatoriosFiltrados: SingleReportData[] = [];
+  public modoFiltro: boolean = false;
+  public isLoading: boolean = false;
 
   constructor(
     private reportService: ReportDataService, 
@@ -47,40 +54,90 @@ export class DailyReportComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.dataSubscription = interval(2000) // Aumentei o intervalo para 2s
-      .pipe(
-        // A cada 2 segundos, busca o último relatório
-        switchMap(() => this.reportService.getLatestReport())
-      )
+    this.iniciarTempoReal();
+  }
+
+  iniciarTempoReal(): void {
+    this.dataSubscription = interval(5000)
+      .pipe(switchMap(() => this.reportService.getLatestReport()))
       .subscribe(data => {
-        console.log('Último relatório recebido!', data);
-        this.latestReport = data;
-        this.calcularKPIs(); // Recalcula os KPIs com os novos dados
+        if (!this.modoFiltro) {
+          this.latestReport = data;
+          this.calcularKPIs();
+        }
       });
   }
 
-  calcularKPIs(): void {
-    if (!this.latestReport) {
-      return; // Se não há dados, não faz nada
+  // --- MÉTODOS PARA O FILTRO ---
+
+  filtrarRelatorios(): void {
+    if (!this.dataInicio || !this.dataFim) {
+      alert('Por favor, selecione as datas de início e fim.');
+      return;
     }
-    // Lógica de cálculo de KPIs baseada em UM único relatório
-    // Exemplo:
-    this.consumoTotalCorrente = this.latestReport.pre1_amp + this.latestReport.pre2_amp + this.latestReport.pre3_amp + this.latestReport.pre4_amp;
-    this.eficienciaMedia = this.latestReport.q90h; // Supondo que q90h seja a eficiência
+
+    if (this.dataSubscription) this.dataSubscription.unsubscribe();
+
+    this.isLoading = true;
+    this.modoFiltro = true;
+    this.latestReport = null;
+
+    const inicioFormatado = this.dataInicio.replace('T', ' ') + ':00';
+    const fimFormatado = this.dataFim.replace('T', ' ') + ':00';
+
+    this.reportService.getReportsByDateTimeRange(inicioFormatado, fimFormatado)
+      .subscribe(dados => {
+        this.relatoriosFiltrados = dados;
+        this.isLoading = false;
+        this.calcularKPIs(); // ATUALIZADO: Calcula os KPIs para os dados filtrados
+        console.log('Dados filtrados recebidos:', dados);
+      });
+  }
+
+  limparFiltro(): void {
+    this.modoFiltro = false;
+    this.relatoriosFiltrados = [];
+    this.dataInicio = '';
+    this.dataFim = '';
+    this.calcularKPIs(); // ATUALIZADO: Zera os KPIs imediatamente
+    this.iniciarTempoReal();
+  }
+
+  // --- MÉTODO DE CÁLCULO DE KPI ATUALIZADO ---
+
+  calcularKPIs(): void {
+    // Se estiver no modo de filtro e houver dados filtrados
+    if (this.modoFiltro && this.relatoriosFiltrados.length > 0) {
+      const totalReports = this.relatoriosFiltrados.length;
+
+      // Soma o consumo de todos os relatórios no array
+      this.consumoTotalCorrente = this.relatoriosFiltrados.reduce((acc, report) => {
+        return acc + (report.pre1_amp || 0) + (report.pre2_amp || 0) + (report.pre3_amp || 0) + (report.pre4_amp || 0);
+      }, 0);
+
+      // Calcula a eficiência média
+      const totalEficiencia = this.relatoriosFiltrados.reduce((acc, report) => acc + (report.q90h || 0), 0);
+      this.eficienciaMedia = totalEficiencia / totalReports;
+
+      // Conta o número de alertas
+      this.alertasNoDia = this.relatoriosFiltrados.filter(report => report.tem2_c > 90.0).length;
+
+    // Se estiver no modo de tempo real e houver um relatório
+    } else if (!this.modoFiltro && this.latestReport) {
+      this.consumoTotalCorrente = this.latestReport.pre1_amp + this.latestReport.pre2_amp + this.latestReport.pre3_amp + this.latestReport.pre4_amp;
+      this.eficienciaMedia = this.latestReport.q90h;
+      const temperaturaElevada = this.latestReport.tem2_c > 90.0;
+      this.alertasNoDia = temperaturaElevada ? 1 : 0;
     
-    // Lógica de alertas
-    const temperaturaElevada = this.latestReport.tem2_c > 90.0;
-    this.alertasNoDia = temperaturaElevada ? 1 : 0;
+    // Se não houver dados em nenhum dos modos
+    } else {
+      this.consumoTotalCorrente = 0;
+      this.eficienciaMedia = 0;
+      this.alertasNoDia = 0;
+    }
   }
 
   ngOnDestroy(): void {
-    if (this.dataSubscription) {
-      this.dataSubscription.unsubscribe();
-    }
-  }
-
-  abrirGrafico(report: SingleReportData): void {
-    console.log('Abrir gráfico para:', report);
-    // A lógica do modal pode precisar ser ajustada para receber um SingleReportData
+    if (this.dataSubscription) this.dataSubscription.unsubscribe();
   }
 }

--- a/src/app/services/report-data.ts
+++ b/src/app/services/report-data.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Observable, of, throwError } from 'rxjs';
-import { catchError, tap } from 'rxjs/operators';
+import { catchError, tap, map } from 'rxjs/operators';
 
-// Imports necessários
 import { SingleReportData } from '../modal/single-report-data/single-report-data';
 import { HistoryDetailsModal } from '../modal/history-details-modal/history-details-modal';
 
@@ -16,24 +15,26 @@ export class ReportDataService {
   constructor(private http: HttpClient) { }
 
   /**
-   * Busca apenas o último registo da tabela de relatórios.
-   * @returns Um Observable que emite um único objeto SingleReportData.
+   * Busca a lista completa e retorna o primeiro item.
    */
   getLatestReport(): Observable<SingleReportData> {
     const token = localStorage.getItem('user_token');
     const headers = new HttpHeaders({ 'Authorization': `Bearer ${token}` });
-    const latestReportUrl = `${this.API_URL}/latest`;
 
-    return this.http.get<SingleReportData>(latestReportUrl, { headers }).pipe(
-      tap(data => console.log('Serviço: Último relatório recebido:', data)),
+    return this.http.get<SingleReportData[]>(this.API_URL, { headers }).pipe(
+      map(reports => {
+        if (!reports || reports.length === 0) {
+          return null as any;
+        }
+        return reports[0];
+      }),
+      tap(data => console.log('Serviço: Primeiro relatório da lista recebido:', data)),
       catchError(this.handleError)
     );
   }
   
   /**
-   * Busca um registo de relatório específico com base numa data e hora.
-   * @param dateTimeString Uma string representando a data e hora.
-   * @returns Um Observable que emite os dados do relatório encontrado.
+   * Busca um relatório específico por data e hora (requer endpoint no backend).
    */
   getReportByDateTime(dateTimeString: string): Observable<SingleReportData> {
     const token = localStorage.getItem('user_token');
@@ -48,20 +49,46 @@ export class ReportDataService {
   }
 
   /**
-   * Busca um histórico mockado de relatórios.
+   * ATUALIZADO: Busca TODOS os relatórios e os filtra por data/hora no FRONTEND.
+   * @param startDateTime A data e hora de início no formato 'YYYY-MM-DD HH:MM:SS'.
+   * @param endDateTime A data e hora de fim no formato 'YYYY-MM-DD HH:MM:SS'.
+   * @returns Um Observable que emite um array de relatórios filtrados.
    */
+  getReportsByDateTimeRange(startDateTime: string, endDateTime: string): Observable<SingleReportData[]> {
+    const token = localStorage.getItem('user_token');
+    const headers = new HttpHeaders({ 'Authorization': `Bearer ${token}` });
+
+    // 1. Busca o array COMPLETO de relatórios, que a sua API já fornece.
+    return this.http.get<SingleReportData[]>(this.API_URL, { headers }).pipe(
+      map(allReports => {
+        if (!allReports) {
+          return []; // Retorna array vazio se a resposta da API for nula.
+        }
+
+        // 2. Converte as strings do filtro para objetos Date para uma comparação segura.
+        const startDate = new Date(startDateTime);
+        const endDate = new Date(endDateTime);
+
+        // 3. Filtra o array aqui mesmo, no frontend.
+        return allReports.filter(report => {
+          const reportDate = new Date(report.data_hora);
+          // A condição retorna 'true' apenas para os relatórios dentro do intervalo.
+          return reportDate >= startDate && reportDate <= endDate;
+        });
+      }),
+      tap(filteredData => console.log(`Serviço: ${filteredData.length} relatórios encontrados no intervalo (filtro no frontend).`)),
+      catchError(this.handleError)
+    );
+  }
+
   getReportHistory(): Observable<HistoryDetailsModal[]> {
     console.log('A buscar dados mocados do histórico...');
     const mockHistory: HistoryDetailsModal[] = [
-      { id: '20250714', data: '14/07/2025', resumo: 'Eficiência média: 98.2%. 2 Alertas registados.' },
-      { id: '20250713', data: '13/07/2025', resumo: 'Eficiência média: 97.5%. 1 Alarme crítico.' },
+        { id: '20250714', data: '14/07/2025', resumo: 'Eficiência média: 98.2%.' },
     ];
     return of(mockHistory);
   }
 
-  /**
-   * Função privada para tratamento centralizado de erros de HTTP.
-   */
   private handleError(error: HttpErrorResponse) {
     if (error.status === 401) {
       console.error('Erro de Autenticação! O token pode ser inválido ou ter expirado.', error);


### PR DESCRIPTION
Introduces a filter section to the daily report page, allowing users to select a start and end date/time to view filtered report data. Updates KPIs and table display to support both real-time and filtered modes. Refactors service to fetch and filter reports by date range on the frontend.