### PR TITLE
Add print functionality for KPI section

### DIFF
--- a/src/app/pages/daily-report/daily-report.css
+++ b/src/app/pages/daily-report/daily-report.css
@@ -113,3 +113,55 @@ table {
 .mat-mdc-cell, .mat-mdc-header-cell {
   padding: 8px 16px;
 }
+/* ... seus estilos existentes ... */
+
+.kpi-value {
+  font-size: 2.2em;
+  font-weight: 700;
+  margin: 8px 0 0 0;
+  color: #005a9c;
+}
+
+/* --- SECÇÃO DE ESTILOS PARA IMPRESSÃO ATUALIZADA --- */
+@media print {
+  /* Esconde tudo por defeito */
+  body * {
+    visibility: hidden;
+  }
+
+  /* Torna visível o header, o grid de KPIs e o conteúdo deles */
+  /* Assumimos que o seu header tem a tag <app-header> */
+  app-header, app-header *,
+  .kpi-grid, .kpi-grid * {
+    visibility: visible;
+  }
+  
+  /* Esconde elementos indesejados dentro do header na impressão */
+  app-header app-logout-button, app-header nav {
+      visibility: hidden;
+  }
+
+  /* Posiciona os elementos na página de impressão */
+  app-header {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+  }
+
+  .kpi-grid {
+    /* Ajusta a posição para vir depois do header */
+    position: absolute;
+    left: 0;
+    top: 80px; /* Ajuste este valor conforme a altura do seu header */
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Remove sombras e fundos desnecessários na impressão */
+  .kpi-card {
+    box-shadow: none;
+    border: 1px solid #ccc;
+  }
+}

--- a/src/app/pages/daily-report/daily-report.html
+++ b/src/app/pages/daily-report/daily-report.html
@@ -84,6 +84,10 @@
       <div class="filter-actions">
         <button mat-flat-button color="primary" (click)="filtrarRelatorios()">Filtrar</button>
         <button mat-stroked-button (click)="limparFiltro()">Limpar Filtro</button>
+        <!-- NOVO BOTÃO DE IMPRESSÃO -->
+        <button mat-icon-button class="print-button" color="accent" (click)="imprimirKPIs()" matTooltip="Imprimir KPIs">
+          <mat-icon>print</mat-icon>
+        </button>
       </div>
     </div>
   </mat-card>

--- a/src/app/pages/daily-report/daily-report.ts
+++ b/src/app/pages/daily-report/daily-report.ts
@@ -161,4 +161,8 @@ export class DailyReportComponent implements OnInit {
     if (!dataArray || dataArray.length < 6) return null;
     return new Date(dataArray[0], dataArray[1] - 1, dataArray[2], dataArray[3], dataArray[4], dataArray[5]);
   }
+
+    imprimirKPIs(): void {
+    window.print();
+  }
 }


### PR DESCRIPTION
Introduces a print button to the filter actions, enabling users to print only the KPI grid and header. Updates CSS to optimize print layout by hiding unnecessary elements and adjusting positioning for a cleaner print output. Implements imprimirKPIs() method to trigger browser print.