### PR TITLE
Show header based on current route

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,9 +1,5 @@
-<!-- Ficheiro: src/app/app.component.html -->
+<!-- O cabeçalho só é renderizado se a nossa variável 'showHeader' for 'true' -->
+<app-header *ngIf="showHeader"></app-header>
 
-<!-- O cabeçalho só é renderizado se o nosso "jornal" (isLoggedIn$) disser 'true' -->
-@if (isLoggedIn$ | async) {
-  <app-header></app-header>
-}
-
-<!-- O router-outlet é responsável por carregar a página atual (seja o login ou o dashboard) -->
+<!-- O router-outlet continua a carregar a página atual -->
 <router-outlet></router-outlet>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,23 +1,35 @@
-// Ficheiro: src/app/app.component.ts
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterOutlet } from '@angular/router';
-import { HeaderComponent } from './components/header/header';
-import { AuthService } from './services/auth'; // Importa o serviço de autenticação
-import { Observable } from 'rxjs';
+// 1. Importe o Router e os eventos de navegação
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
+import { HeaderComponent } from './components/header/header'; 
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
   standalone: true,
   imports: [CommonModule, RouterOutlet, HeaderComponent],
   templateUrl: './app.html',
-  styleUrl: './app.css'
+  styleUrls: ['./app.css']
 })
 export class AppComponent {
-  isLoggedIn$: Observable<boolean>; // Cria uma variável para guardar o "jornal" de login
+  title = 'siemens-web-front-end';
+  
+  // 2. Crie uma propriedade para controlar a visibilidade do header
+  showHeader: boolean = false;
 
-  constructor(private authService: AuthService) {
-    // Subscreve ao "jornal" do serviço para saber sempre se o utilizador está logado
-    this.isLoggedIn$ = this.authService.isLoggedIn$;
+  constructor(private router: Router) {
+    // 3. "Ouve" as mudanças de rota
+    this.router.events.pipe(
+      // Filtra apenas pelos eventos que acontecem no FIM da navegação
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd)
+    ).subscribe((event: NavigationEnd) => {
+      // 4. Verifica se a URL atual é a de login
+      if (event.urlAfterRedirects === '/login') {
+        this.showHeader = false; // Se for, esconde o header
+      } else {
+        this.showHeader = true; // Se não for, mostra o header
+      }
+    });
   }
 }


### PR DESCRIPTION
Replaced login state-based header rendering with route-based logic. The header is now only shown when the current route is not '/login', improving control over header visibility.