### PR TITLE
Add comparison report page and routing

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,30 +1,23 @@
 import { Routes } from '@angular/router';
-// 1. Importe o seu AuthGuard
 import { authGuard } from './auth-guard';
 import { LoginComponent } from './pages/login/login';
 import { DailyReportComponent } from './pages/daily-report/daily-report';
+// 1. Importe o novo componente
+import { ComparisonReportComponent } from './pages/comparison-report/comparison-report';
 
 export const routes: Routes = [
-  // A rota de login não precisa de proteção
-  { 
-    path: 'login', 
-    component: LoginComponent 
-  },
-  // A rota de relatórios AGORA está protegida pelo AuthGuard
+  { path: 'login', component: LoginComponent },
   { 
     path: 'relatorios', 
     component: DailyReportComponent,
-    canActivate: [authGuard] // 2. Adicione esta linha para ativar o "guarda"
+    canActivate: [authGuard]
   },
-  // Rota padrão para redirecionar para o login ou para os relatórios
-  { 
-    path: '', 
-    redirectTo: '/login', 
-    pathMatch: 'full' 
+  // 2. Adicione a nova rota de comparação
+  {
+    path: 'comparacao',
+    component: ComparisonReportComponent,
+    canActivate: [authGuard]
   },
-  // Rota "catch-all" para qualquer outro endereço
-  { 
-    path: '**', 
-    redirectTo: '/login' 
-  }
+  { path: '', redirectTo: '/login', pathMatch: 'full' },
+  { path: '**', redirectTo: '/login' }
 ];

--- a/src/app/components/header/header.ts
+++ b/src/app/components/header/header.ts
@@ -16,5 +16,6 @@ export class HeaderComponent {
   // CORRIGIDO: A lista agora tem apenas um link e o label foi atualizado.
   navLinks = [
     { path: 'relatorios', label: 'Relatórios' },
+    { path: 'comparacao', label: 'Comparação' },
   ];
 }

--- a/src/app/pages/comparison-report/comparison-report.css
+++ b/src/app/pages/comparison-report/comparison-report.css
@@ -1,0 +1,84 @@
+.report-container {
+  padding: 25px;
+  max-width: 1200px;
+  margin: auto;
+}
+
+.filter-card {
+  margin-bottom: 20px;
+}
+
+.period-selectors {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  padding: 16px;
+}
+
+.date-range-picker {
+  flex: 1;
+  min-width: 280px;
+}
+
+.filter-actions {
+  padding: 0 16px 16px;
+}
+
+.results-container h3 {
+  border-bottom: 2px solid #005a9c;
+  padding-bottom: 10px;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.kpi-card {
+  padding: 16px;
+}
+
+.kpi-title {
+  margin: 0;
+  font-size: 1.1em;
+  font-weight: 500;
+  color: #333;
+}
+
+.comparison-values {
+  display: flex;
+  justify-content: space-between;
+  margin: 8px 0;
+  font-size: 0.9em;
+  color: #666;
+}
+
+.difference {
+  font-size: 2.5em;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.difference.positive {
+  color: #28a745; /* Verde */
+}
+
+.difference.negative {
+  color: #dc3545; /* Vermelho */
+}
+
+.kpi-sub-title {
+  margin-top: 8px;
+  font-size: 0.8em;
+  color: #888;
+  text-align: center;
+}
+
+.loading-message {
+  text-align: center;
+  padding: 40px;
+}

--- a/src/app/pages/comparison-report/comparison-report.html
+++ b/src/app/pages/comparison-report/comparison-report.html
@@ -1,0 +1,58 @@
+<div class="report-container">
+  <h2>Comparação de Períodos</h2>
+
+  <mat-card class="filter-card">
+    <div class="period-selectors">
+      <!-- Seletor Período 1 -->
+      <mat-form-field appearance="outline" class="date-range-picker">
+        <mat-label>Período 1 (Base)</mat-label>
+        <mat-date-range-input [rangePicker]="picker1">
+          <input matStartDate placeholder="Data de início" [(ngModel)]="startDate1">
+          <input matEndDate placeholder="Data de fim" [(ngModel)]="endDate1">
+        </mat-date-range-input>
+        <mat-datepicker-toggle matSuffix [for]="picker1"></mat-datepicker-toggle>
+        <mat-date-range-picker #picker1></mat-date-range-picker>
+      </mat-form-field>
+
+      <!-- Seletor Período 2 -->
+      <mat-form-field appearance="outline" class="date-range-picker">
+        <mat-label>Período 2 (Comparação)</mat-label>
+        <mat-date-range-input [rangePicker]="picker2">
+          <input matStartDate placeholder="Data de início" [(ngModel)]="startDate2">
+          <input matEndDate placeholder="Data de fim" [(ngModel)]="endDate2">
+        </mat-date-range-input>
+        <mat-datepicker-toggle matSuffix [for]="picker2"></mat-datepicker-toggle>
+        <mat-date-range-picker #picker2></mat-date-range-picker>
+      </mat-form-field>
+    </div>
+    <mat-card-actions class="filter-actions">
+      <button mat-flat-button color="primary" (click)="compararPeriodos()">Comparar</button>
+    </mat-card-actions>
+  </mat-card>
+
+  <!-- Resultados da Comparação -->
+  <div *ngIf="isLoading" class="loading-message">
+    A comparar períodos...
+  </div>
+
+  <div *ngIf="!isLoading && comparisonDone" class="results-container">
+    <h3>Resultados da Comparação</h3>
+    <div class="kpi-grid">
+      @for (result of results; track result.metricName) {
+        <mat-card class="kpi-card">
+          <p class="kpi-title">{{ result.metricName }}</p>
+          <div class="comparison-values">
+            <span>P1: {{ result.value1.toFixed(1) }}{{ result.unit }}</span>
+            <span>P2: {{ result.value2.toFixed(1) }}{{ result.unit }}</span>
+          </div>
+          <div class="difference" [ngClass]="{'positive': result.difference > 0, 'negative': result.difference < 0}">
+            <mat-icon *ngIf="result.difference > 0">arrow_upward</mat-icon>
+            <mat-icon *ngIf="result.difference < 0">arrow_downward</mat-icon>
+            <span>{{ result.difference.toFixed(1) }}%</span>
+          </div>
+          <p class="kpi-sub-title">Variação do Período 2 em relação ao Período 1</p>
+        </mat-card>
+      }
+    </div>
+  </div>
+</div>

--- a/src/app/pages/comparison-report/comparison-report.spec.ts
+++ b/src/app/pages/comparison-report/comparison-report.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ComparisonReport } from './comparison-report';
+
+describe('ComparisonReport', () => {
+  let component: ComparisonReport;
+  let fixture: ComponentFixture<ComparisonReport>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComparisonReport]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ComparisonReport);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/comparison-report/comparison-report.ts
+++ b/src/app/pages/comparison-report/comparison-report.ts
@@ -1,0 +1,139 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule, MAT_DATE_LOCALE } from '@angular/material/core';
+import { MatIconModule } from '@angular/material/icon';
+import { forkJoin } from 'rxjs';
+
+import { SingleReportData } from '../../modal/single-report-data/single-report-data'; 
+import { ReportDataService } from '../../services/report-data'; 
+
+// Interface para guardar os KPIs calculados
+interface CalculatedKPIs {
+  mediaTem2C: number;
+  mediaQ90h: number;
+  mediaConz1Nivel: number;
+  mediaConz2Nivel: number;
+  mediaPre1Amp: number;
+  mediaPre2Amp: number;
+  mediaPre3Amp: number;
+  mediaPre4Amp: number;
+}
+
+// Interface para guardar os resultados da comparação
+interface ComparisonResult {
+  metricName: string;
+  value1: number;
+  value2: number;
+  difference: number;
+  unit: string;
+}
+
+@Component({
+  selector: 'app-comparison-report',
+  standalone: true,
+  imports: [
+    CommonModule, FormsModule, MatCardModule, MatFormFieldModule, MatInputModule,
+    MatButtonModule, MatDatepickerModule, MatNativeDateModule, MatIconModule
+  ],
+  templateUrl: './comparison-report.html',
+  styleUrl: './comparison-report.css',
+  providers: [
+    { provide: MAT_DATE_LOCALE, useValue: 'pt-BR' }
+  ]
+})
+export class ComparisonReportComponent {
+  
+  public startDate1: Date | null = null;
+  public endDate1: Date | null = null;
+  public startDate2: Date | null = null;
+  public endDate2: Date | null = null;
+  public isLoading: boolean = false;
+  public results: ComparisonResult[] = [];
+  public comparisonDone: boolean = false;
+
+  constructor(private reportService: ReportDataService) {}
+
+  compararPeriodos(): void {
+    if (!this.startDate1 || !this.endDate1 || !this.startDate2 || !this.endDate2) {
+      alert('Por favor, selecione os dois períodos para comparação.');
+      return;
+    }
+
+    this.isLoading = true;
+    this.comparisonDone = true;
+
+    forkJoin({
+      periodo1: this.reportService.getReportsByDateRange(this.startDate1, this.endDate1),
+      periodo2: this.reportService.getReportsByDateRange(this.startDate2, this.endDate2)
+    }).subscribe(({ periodo1, periodo2 }) => {
+      
+      const kpisPeriodo1 = this.calculateKPIsForPeriod(periodo1);
+      const kpisPeriodo2 = this.calculateKPIsForPeriod(periodo2);
+
+      this.results = this.calculateComparison(kpisPeriodo1, kpisPeriodo2);
+      
+      this.isLoading = false;
+    });
+  }
+
+  /**
+   * ATUALIZADO: A função agora calcula a média para todas as métricas.
+   */
+  calculateKPIsForPeriod(reports: SingleReportData[]): CalculatedKPIs {
+    const defaultKPIs = {
+      mediaTem2C: 0, mediaQ90h: 0, mediaConz1Nivel: 0, mediaConz2Nivel: 0,
+      mediaPre1Amp: 0, mediaPre2Amp: 0, mediaPre3Amp: 0, mediaPre4Amp: 0
+    };
+
+    if (!reports || reports.length === 0) {
+      return defaultKPIs;
+    }
+
+    const calculateAverage = (metric: keyof SingleReportData): number => {
+      const validReports = reports.filter(r => typeof r[metric] === 'number');
+      if (validReports.length === 0) return 0;
+      const total = validReports.reduce((acc, r) => acc + (r[metric] as number), 0);
+      return total / validReports.length;
+    };
+    
+    return {
+      mediaTem2C: calculateAverage('tem2C'),
+      mediaQ90h: calculateAverage('q90h'),
+      mediaConz1Nivel: calculateAverage('conz1Nivel'),
+      mediaConz2Nivel: calculateAverage('conz2Nivel'),
+      mediaPre1Amp: calculateAverage('pre1Amp'),
+      mediaPre2Amp: calculateAverage('pre2Amp'),
+      mediaPre3Amp: calculateAverage('pre3Amp'),
+      mediaPre4Amp: calculateAverage('pre4Amp'),
+    };
+  }
+
+  calculateComparison(kpis1: CalculatedKPIs, kpis2: CalculatedKPIs): ComparisonResult[] {
+    const compare = (metricName: string, value1: number, value2: number, unit: string): ComparisonResult => {
+      let difference = 0;
+      if (value1 !== 0) {
+        difference = ((value2 - value1) / value1) * 100;
+      } else if (value2 > 0) {
+        difference = 100;
+      }
+      return { metricName, value1, value2, difference, unit };
+    };
+
+    return [
+      compare('Média de Temperatura', kpis1.mediaTem2C, kpis2.mediaTem2C, '°C'),
+      compare('Média de Eficiência', kpis1.mediaQ90h, kpis2.mediaQ90h, '%'),
+      compare('Média Nível Conz1', kpis1.mediaConz1Nivel, kpis2.mediaConz1Nivel, ''),
+      compare('Média Nível Conz2', kpis1.mediaConz2Nivel, kpis2.mediaConz2Nivel, ''),
+      compare('Média Amp Pre1', kpis1.mediaPre1Amp, kpis2.mediaPre1Amp, 'A'),
+      compare('Média Amp Pre2', kpis1.mediaPre2Amp, kpis2.mediaPre2Amp, 'A'),
+      compare('Média Amp Pre3', kpis1.mediaPre3Amp, kpis2.mediaPre3Amp, 'A'),
+      compare('Média Amp Pre4', kpis1.mediaPre4Amp, kpis2.mediaPre4Amp, 'A'),
+    ];
+  }
+}


### PR DESCRIPTION
Introduces the ComparisonReportComponent with its template, styles, and test. Updates routing to include a protected 'comparacao' route and adds a navigation link in the header. The new page allows users to compare KPIs between two selected periods.