### PR TITLE
Refactor template to Angular 17 syntax and add error handling

### DIFF
--- a/src/app/pages/comparison-report/comparison-report.html
+++ b/src/app/pages/comparison-report/comparison-report.html
@@ -31,28 +31,32 @@
   </mat-card>
 
   <!-- Resultados da Comparação -->
-  <div *ngIf="isLoading" class="loading-message">
-    A comparar períodos...
-  </div>
-
-  <div *ngIf="!isLoading && comparisonDone" class="results-container">
-    <h3>Resultados da Comparação</h3>
-    <div class="kpi-grid">
-      @for (result of results; track result.metricName) {
-        <mat-card class="kpi-card">
-          <p class="kpi-title">{{ result.metricName }}</p>
-          <div class="comparison-values">
-            <span>P1: {{ result.value1.toFixed(1) }}{{ result.unit }}</span>
-            <span>P2: {{ result.value2.toFixed(1) }}{{ result.unit }}</span>
-          </div>
-          <div class="difference" [ngClass]="{'positive': result.difference > 0, 'negative': result.difference < 0}">
-            <mat-icon *ngIf="result.difference > 0">arrow_upward</mat-icon>
-            <mat-icon *ngIf="result.difference < 0">arrow_downward</mat-icon>
-            <span>{{ result.difference.toFixed(1) }}%</span>
-          </div>
-          <p class="kpi-sub-title">Variação do Período 2 em relação ao Período 1</p>
-        </mat-card>
-      }
+  @if (isLoading) {
+    <div class="loading-message">
+      A comparar períodos...
     </div>
-  </div>
+  }
+
+  @if (!isLoading && comparisonDone) {
+    <div class="results-container">
+      <h3>Resultados da Comparação</h3>
+      <div class="kpi-grid">
+        @for (result of results; track result.metricName) {
+          <mat-card class="kpi-card">
+            <p class="kpi-title">{{ result.metricName }}</p>
+            <div class="comparison-values">
+              <span>P1: {{ result.value1.toFixed(1) }}{{ result.unit }}</span>
+              <span>P2: {{ result.value2.toFixed(1) }}{{ result.unit }}</span>
+            </div>
+            <div class="difference" [ngClass]="{'positive': result.difference > 0, 'negative': result.difference < 0}">
+              @if (result.difference > 0) { <mat-icon>arrow_upward</mat-icon> }
+              @if (result.difference < 0) { <mat-icon>arrow_downward</mat-icon> }
+              <span>{{ result.difference.toFixed(1) }}%</span>
+            </div>
+            <p class="kpi-sub-title">Variação do Período 2 em relação ao Período 1</p>
+          </mat-card>
+        }
+      </div>
+    </div>
+  }
 </div>

--- a/src/app/pages/comparison-report/comparison-report.ts
+++ b/src/app/pages/comparison-report/comparison-report.ts
@@ -71,20 +71,23 @@ export class ComparisonReportComponent {
     forkJoin({
       periodo1: this.reportService.getReportsByDateRange(this.startDate1, this.endDate1),
       periodo2: this.reportService.getReportsByDateRange(this.startDate2, this.endDate2)
-    }).subscribe(({ periodo1, periodo2 }) => {
-      
-      const kpisPeriodo1 = this.calculateKPIsForPeriod(periodo1);
-      const kpisPeriodo2 = this.calculateKPIsForPeriod(periodo2);
+    }).subscribe({
+      next: ({ periodo1, periodo2 }) => {
+        const kpisPeriodo1 = this.calculateKPIsForPeriod(periodo1);
+        const kpisPeriodo2 = this.calculateKPIsForPeriod(periodo2);
 
-      this.results = this.calculateComparison(kpisPeriodo1, kpisPeriodo2);
-      
-      this.isLoading = false;
+        this.results = this.calculateComparison(kpisPeriodo1, kpisPeriodo2);
+        
+        this.isLoading = false;
+      },
+      error: (err) => {
+        console.error("Erro ao comparar os períodos:", err);
+        alert("Ocorreu um erro ao buscar os dados. Verifique o console para mais detalhes.");
+        this.isLoading = false;
+      }
     });
   }
 
-  /**
-   * ATUALIZADO: A função agora calcula a média para todas as métricas.
-   */
   calculateKPIsForPeriod(reports: SingleReportData[]): CalculatedKPIs {
     const defaultKPIs = {
       mediaTem2C: 0, mediaQ90h: 0, mediaConz1Nivel: 0, mediaConz2Nivel: 0,


### PR DESCRIPTION
Updated the comparison-report HTML to use Angular 17's @if and @for block syntax, replacing legacy *ngIf and *ngFor. Improved error handling in the TypeScript file by adding an error callback to the forkJoin subscription, displaying an alert and logging errors when data fetching fails.